### PR TITLE
Prevent fatal bower install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-shell": "~0.3.1",
-    "grunt-bower-task": "~0.2.3",
+    "grunt-bower-task": "~0.4.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-clean": "~0.4.1"


### PR DESCRIPTION
Increased grunt-bower-task version number (dependency) in package.json to prevent bower install error as per https://github.com/yatskevich/grunt-bower-task/issues/157